### PR TITLE
Add build script to configure Python linking on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "pathdiff",
  "predicates",
  "pyo3",
+ "pyo3-build-config",
  "regex",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["rlib", "cdylib"]
 
 [features]
 default = []
-python = ["pyo3"]
+python = ["pyo3", "pyo3-build-config"]
 
 [dependencies]
 anyhow = "1.0"
@@ -30,6 +30,9 @@ globset = "0.4"
 version = "0.21"
 optional = true
 features = ["extension-module", "abi3-py37"]
+
+[build-dependencies]
+pyo3-build-config = { version = "0.21", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    #[cfg(feature = "python")]
+    {
+        if std::env::var_os("CARGO_FEATURE_PYTHON").is_some() {
+            pyo3_build_config::add_extension_module_link_args();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a build script that adds PyO3's extension module link arguments when the `python` feature is enabled
- include the optional `pyo3-build-config` build dependency and activate it alongside the `python` feature

## Testing
- cargo build --release --features python

------
https://chatgpt.com/codex/tasks/task_e_68d3355274448324aae7cf7dc24e7ff5