### PR TITLE
Fix release workflow sdist command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install maturin
         run: pip install maturin
       - name: Build sdist
-        run: maturin sdist --release -F python --out dist
+        run: maturin sdist --out dist
       - name: Upload sdist artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- remove unsupported release and feature flags from the sdist packaging step

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d616bb853c832498477a9c6603680a