### PR TITLE
Improve progress utilities and add tests

### DIFF
--- a/python/crabpack/__init__.py
+++ b/python/crabpack/__init__.py
@@ -3,9 +3,19 @@ from __future__ import annotations
 
 from importlib import metadata as _metadata
 
-from .crabpack import pack
+from .progress import format_time, progressbar
 
-__all__ = ["pack"]
+try:  # pragma: no cover - depends on the Rust extension being built
+    from .crabpack import pack
+except ImportError:  # pragma: no cover - exercised indirectly in tests
+    def pack(*_args, **_kwargs):
+        raise ImportError(
+            "The crabpack native module is not available. "
+            "Build the project first (see README)."
+        )
+
+
+__all__ = ["pack", "progressbar", "format_time"]
 
 
 def __getattr__(name: str):

--- a/python/crabpack/progress.py
+++ b/python/crabpack/progress.py
@@ -1,0 +1,129 @@
+"""Progress reporting utilities used by the Python packaging interface.
+
+The implementation is intentionally a direct Python port of the progress bar
+used by ``venv-pack``.  Keeping this code in Python avoids introducing a Rust
+extension module for what ultimately boils down to formatting text and writing
+it to an ``io`` stream; the heavy work still happens in Python land during the
+iteration that drives the pack operation.
+"""
+
+from __future__ import absolute_import, division
+
+import sys
+import threading
+import time
+from timeit import default_timer
+from typing import Generic, Iterable, Iterator, Optional, TextIO, TypeVar
+
+__all__ = ["progressbar", "format_time"]
+
+T = TypeVar("T")
+
+
+def format_time(t: float) -> str:
+    """Format seconds into a human readable form.
+
+    >>> format_time(10.4)
+    '10.4s'
+    >>> format_time(1000.4)
+    '16min 40.4s'
+    """
+
+    m, s = divmod(t, 60)
+    h, m = divmod(m, 60)
+    if h:
+        return "{0:2.0f}hr {1:2.0f}min {2:4.1f}s".format(h, m, s)
+    if m:
+        return "{0:2.0f}min {1:4.1f}s".format(m, s)
+    return "{0:4.1f}s".format(s)
+
+
+class progressbar(Generic[T]):
+    """A simple progressbar for iterables.
+
+    Displays a progress bar showing progress through an iterable.
+
+    Parameters
+    ----------
+    iterable : iterable
+        The object to iterate over.
+    width : int, optional
+        Width of the bar in characters.
+    enabled : bool, optional
+        Whether to log progress. Useful for turning off progress reports
+        without changing your code. Default is True.
+    file : file, optional
+        Where to log progress. Default is ``sys.stdout``.
+
+    Example
+    -------
+    >>> with progressbar(iterable) as itbl:  # doctest: +SKIP
+    ...     for i in itbl:
+    ...         do_stuff(i)
+    [########################################] | 100% Completed | 5.2 s
+    """
+
+    def __init__(
+        self,
+        iterable: Iterable[T],
+        width: int = 40,
+        enabled: bool = True,
+        file: Optional[TextIO] = None,
+    ) -> None:
+        self._iterable = iterable
+        self._ndone = 0
+        self._ntotal = len(iterable)
+        self._width = width
+        self._enabled = enabled
+        self._file = sys.stdout if file is None else file
+        self._start_time: float
+        self._running: bool
+        self._timer: threading.Thread
+
+    def __enter__(self) -> "progressbar[T]":
+        if self._enabled:
+            self._start_time = default_timer()
+            # Start background thread
+            self._running = True
+            self._timer = threading.Thread(target=self._timer_func)
+            self._timer.daemon = True
+            self._timer.start()
+        return self
+
+    def __exit__(self, type, value, traceback) -> None:
+        if self._enabled:
+            self._running = False
+            self._timer.join()
+            self._update_bar()
+            self._file.write("\n")
+            self._file.flush()
+
+    def __iter__(self) -> Iterator[T]:
+        for i in self._iterable:
+            self._ndone += 1
+            yield i
+
+    def _timer_func(self) -> None:
+        while self._running:
+            self._update_bar()
+            time.sleep(0.1)
+
+    def _update_bar(self) -> None:
+        elapsed = default_timer() - self._start_time
+        frac = (self._ndone / self._ntotal) if self._ntotal else 1
+        bar = "#" * int(self._width * frac)
+        percent = int(100 * frac)
+        elapsed_str = format_time(elapsed)
+        msg = "\r[{0:<{1}}] | {2}% Completed | {3}".format(
+            bar,
+            self._width,
+            percent,
+            elapsed_str,
+        )
+        try:
+            self._file.write(msg)
+            self._file.flush()
+        except ValueError:
+            # Writing to closed file handles raises ValueError; mirror the
+            # behaviour of the original implementation by silently ignoring it.
+            pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test configuration for importing the local crabpack Python package."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PYTHON_SRC = PROJECT_ROOT / "python"
+if str(PYTHON_SRC) not in sys.path:
+    sys.path.insert(0, str(PYTHON_SRC))

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,39 @@
+"""Tests for the Python progress bar utilities."""
+
+from __future__ import annotations
+
+import io
+from typing import Iterable
+
+import pytest
+
+from crabpack.progress import format_time, progressbar
+
+
+@pytest.mark.parametrize(
+    "seconds, expected",
+    [
+        (0.4, " 0.4s"),
+        (10.4, "10.4s"),
+        (100.4, " 1min 40.4s"),
+        (3661.2, " 1hr  1min  1.2s"),
+    ],
+)
+def test_format_time(seconds: float, expected: str) -> None:
+    assert format_time(seconds) == expected
+
+
+def test_progressbar_writes_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    iterable: Iterable[int] = range(3)
+    buffer = io.StringIO()
+
+    # Speed up the background thread while keeping the behaviour identical.
+    monkeypatch.setattr("crabpack.progress.time.sleep", lambda _t: None)
+
+    with progressbar(iterable, file=buffer) as it:
+        for _ in it:
+            pass
+
+    output = buffer.getvalue()
+    assert "] | 100% Completed |" in output
+    assert output.endswith("\n")


### PR DESCRIPTION
## Summary
- add the venv-pack progressbar utility to the crabpack python package
- document why the progress bar remains a pure Python helper, export it from the package, and add unit tests that cover its behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ffe02d1a9c8324942b3e2ec3d828ef