### PR TITLE
Add GitHub Action to automate releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,102 @@
+name: Automated release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine versions
+        id: versions
+        run: |
+          python - <<'PY'
+          import os
+          import subprocess
+          from pathlib import Path
+
+          def read_version(text: str) -> str:
+              in_package = False
+              for raw_line in text.splitlines():
+                  line = raw_line.strip()
+                  if not line or line.startswith("#"):
+                      continue
+                  if line.startswith("["):
+                      in_package = line == "[package]"
+                      continue
+                  if in_package and line.startswith("version"):
+                      _, value = line.split("=", 1)
+                      return value.strip().strip('"')
+              raise SystemExit("Could not find package version in Cargo.toml")
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          current_contents = Path("Cargo.toml").read_text(encoding="utf-8")
+          current_version = read_version(current_contents)
+
+          previous_version = ""
+          result = subprocess.run(
+              ["git", "rev-parse", "HEAD^"],
+              stdout=subprocess.DEVNULL,
+              stderr=subprocess.DEVNULL,
+          )
+          if result.returncode == 0:
+              previous_contents = subprocess.run(
+                  ["git", "show", "HEAD^:Cargo.toml"],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              ).stdout
+              previous_version = read_version(previous_contents)
+
+          with output_path.open("a", encoding="utf-8") as fh:
+              fh.write(f"current={current_version}\n")
+              if previous_version:
+                  fh.write(f"previous={previous_version}\n")
+          PY
+
+      - name: Check for version change
+        id: changed
+        run: |
+          if [ -z "${{ steps.versions.outputs.previous }}" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.versions.outputs.current }}" != "${{ steps.versions.outputs.previous }}" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for existing tag
+        id: tag
+        run: |
+          if git rev-parse "v${{ steps.versions.outputs.current }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub release
+        if: steps.changed.outputs.changed == 'true' && steps.tag.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.versions.outputs.current }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v$VERSION" \
+            --target "$GITHUB_SHA" \
+            --title "v$VERSION" \
+            --generate-notes
+
+      - name: Skip note
+        if: steps.changed.outputs.changed != 'true' || steps.tag.outputs.exists == 'true'
+        run: |
+          echo "No new release was created. Either the version did not change or the tag already exists."


### PR DESCRIPTION
## Summary
- add a workflow that monitors pushes to main for Cargo.toml version bumps
- automatically create a version tag and published GitHub release with generated notes when needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69001149cd6c8324b92ad9e453003b4b